### PR TITLE
Add action permission for clear_cert, use filter to find host instance

### DIFF
--- a/app/controllers/cert_reaper/hosts_controller.rb
+++ b/app/controllers/cert_reaper/hosts_controller.rb
@@ -6,34 +6,31 @@ module CertReaper
   class HostsController < ::HostsController
     # change layout if needed
     # layout 'cert_reaper/layouts/new_layout'
+    before_action :find_resource, :only => [:clear_cert]
 
     def clear_cert
       # automatically renders view/cert_reaper/hosts/clear_action
       logger.warn _("DUG: params is: #{params.inspect}.")
       logger.warn _("DUG: class of params[:id] is: #{params[:id].class}.")
-      logger.warn _("DUG: inspect of params[:id] is: #{params[:id].instpect}.")
-      my_host = Host.find_by_name(params[:id])
+      logger.warn _("DUG: inspect of params[:id] is: #{params[:id].inspect}.")
       logger.warn _("DUG: Smart Proxy is #{SmartProxy.inspect}")
       logger.warn _("DUG: Foreman settings we know are: #{SETTINGS.inspect}");
 
-      if my_host
-        logger.warn _("DUG: Found host in DB via '#{params[:id]}', my_host is: #{my_host.inspect}.")
-        if my_host.try(:certname)
-          logger.warn _("DUG: Successfully found the certificate for this host, you rock!")
-          logger.warn _("DUG: Deleting certificate #{my_host.certname}.")
-          api = ProxyAPI::Puppetca.new({:url => my_host.puppet_ca_proxy.url})
-          api.del_certificate(my_host.certname)
-          logger.warn _("DUG: Deleted certificate #{my_host.certname}.")
-      
-          logger.warn _("DUG: local variables: #{local_variables}")
-          logger.warn _("DUG: instance_variables: #{instance_variables}")
-          logger.warn _("DUG: global variables: #{global_variables}")
-        else
-          logger.warn _("DUG: No certificate to delete: #{my_host.inspect}.")
-        end
+      logger.warn _("DUG: Found host in DB via '#{params[:id]}', my_host is: #{@host.inspect}.")
+
+      if @host.try(:certname)
+        logger.warn _("DUG: Successfully found the certificate for this host, you rock!")
+        logger.warn _("DUG: Deleting certificate #{@host.certname}.")
+        api = ProxyAPI::Puppetca.new({:url => @host.puppet_ca_proxy.url})
+        api.del_certificate(@host.certname)
+        logger.warn _("DUG: Deleted certificate #{@host.certname}.")
+        logger.warn _("DUG: local variables: #{local_variables}")
+        logger.warn _("DUG: instance_variables: #{instance_variables}")
+        logger.warn _("DUG: global variables: #{global_variables}")
       else
-        logger.warn _("DUG: No host found in database!")
+        logger.warn _("DUG: No certificate to delete: #{@host.inspect}.")
       end
+
       # logger.warn _(HostsController.public_instance_methods)
       # logger.warn _(self.public_methods)
       # logger.warn _(self.singleton_methods)
@@ -43,6 +40,7 @@ module CertReaper
     end
 
     private
+
     def multiple_clear_cert
       @hosts.each do |host|
         logger.warn _("DUG: Deleting certificate #{@host.certname}.")
@@ -51,5 +49,13 @@ module CertReaper
       redirect_back_or_to hosts_path
     end
 
+    def action_permission
+      case params[:action]
+      when 'clear_cert'
+        :edit
+      else
+        super
+      end
+    end
   end
 end

--- a/lib/cert_reaper/engine.rb
+++ b/lib/cert_reaper/engine.rb
@@ -63,7 +63,7 @@ module CertReaper
       begin
         Host::Managed.send(:include, CertReaper::HostExtensions)
         HostsHelper.send(:include, CertReaper::HostsHelperExtensions)
-        HostsController.send(:include, CertReaper::HostsControllerExtensions)
+        HostsController.send(:include, CertReaper::Concerns::HostsControllerExtensions)
       rescue => e
         Rails.logger.warn "CertReaper: skipping engine hook (#{e})"
       end


### PR DESCRIPTION
Hi,
I took a brief look at your plugin and `show_appropriate_host_buttons` helper we talked about on Friday. Seems like your helper extension works fine.

A couple of suggestions: 
* You can use `before_action` to find and instance of host for you.
* You need to state a permission for controller action if your action has a custom name  (like `clear_cert`), therefore I added the `action_permission` method.
* a namespace fix

Additional thought:
* From what I saw there is no reason for `CertReaper::HostsController` to inherit from `HostsController`. I would just inherit from `ApplicationController`, but you probably have reasons I do not know about (like future work/feature).
 
Let me know if you need anything else.